### PR TITLE
Export Shopware Instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ import 'shopware-admin-vue-standalone/dist/shopware-admin-vue-standalone.css';
 Vue.use(VueShopwareAdminStandalone);
 ```
 
+Using Shopware global instance
+
+```javascript
+import { Shopware } from 'shopware-admin-vue-standalone';
+```
+
 ### With vue-i18n
 
 If you want to use the existing translations, you need to install vue-18n.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shopware-admin-vue-standalone",
   "description": "Standalone Shopware administration components for Vue",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "main": "dist/shopware-admin-vue-standalone.common.js",
   "files": [
     "dist/*"

--- a/src/install.js
+++ b/src/install.js
@@ -1,4 +1,5 @@
 import Main from './load';
+import Shopware from 'src/core/shopware';
 
 const VueShopwareAdminStandalone = {
   install(Vue, options) {
@@ -20,4 +21,5 @@ if (typeof window !== 'undefined' && window.Vue) {
   window.Vue.use(VueShopwareAdminStandalone);
 }
 
+export const Shopware = Shopware;
 export default VueShopwareAdminStandalone;


### PR DESCRIPTION
Currently, if I want to use Shopware instance I need to import the whole build file which is quite heavy

```javascript
import 'shopware-admin-vue-standalone/dist/shopware-admin-vue-standalone.js';

console.log(window.Shopware);
```

With this PR, I can easily get the Shopware instance from the lib so I can use Shopware built-in service/helper/utils/mixins/etc

```javascript
import { Shopware } from 'shopware-admin-vue-standalone';
```

I am not sure if there's a better way to do it. Please let me now if you have a better solution.